### PR TITLE
show different keys in secondary pages

### DIFF
--- a/ui/cluster.go
+++ b/ui/cluster.go
@@ -47,6 +47,10 @@ func (v *ClusterView) infoBuilder() *tview.Pages {
 	for _, c := range v.clusters {
 		items := v.infoPagesParam(c)
 		infoFlex := v.buildInfoFlex(*c.ClusterName, items, v.keys)
+		infoJsonFlex := v.buildInfoFlex(*c.ClusterName, items, []KeyInput{
+			{key: "hello", description: "world"},
+		})
+		v.infoPages.AddPage(*c.ClusterArn+"json", infoJsonFlex, true, false)
 		v.infoPages.AddPage(*c.ClusterArn, infoFlex, true, true)
 	}
 	// prevent empty clusters

--- a/ui/cluster.go
+++ b/ui/cluster.go
@@ -18,7 +18,9 @@ type ClusterView struct {
 
 func newClusterView(clusters []types.Cluster, app *App) *ClusterView {
 	return &ClusterView{
-		View:     *newView(app, ClusterPage, basicKeyInputs),
+		View: *newView(app, ClusterPage, basicKeyInputs, secondaryPageKeyMap{
+			JsonPage: jsonPageKeys,
+		}),
 		clusters: clusters,
 	}
 }
@@ -45,13 +47,11 @@ func (app *App) showClustersPage() error {
 // Build info pages for cluster page
 func (v *ClusterView) infoBuilder() *tview.Pages {
 	for _, c := range v.clusters {
+		title := *c.ClusterName
+		entityName := *c.ClusterArn
 		items := v.infoPagesParam(c)
-		infoFlex := v.buildInfoFlex(*c.ClusterName, items, v.keys)
-		infoJsonFlex := v.buildInfoFlex(*c.ClusterName, items, []KeyInput{
-			{key: "hello", description: "world"},
-		})
-		v.infoPages.AddPage(*c.ClusterArn+"json", infoJsonFlex, true, false)
-		v.infoPages.AddPage(*c.ClusterArn, infoFlex, true, true)
+
+		v.buildInfoPages(items, title, entityName)
 	}
 	// prevent empty clusters
 	if len(v.clusters) > 0 && v.clusters[0].ClusterArn != nil {

--- a/ui/container.go
+++ b/ui/container.go
@@ -20,7 +20,9 @@ func newContainerView(containers []types.Container, app *App) *ContainerView {
 		{key: "Enter", description: sshContainer},
 	}...)
 	return &ContainerView{
-		View:       *newView(app, ContainerPage, keys),
+		View: *newView(app, ContainerPage, keys, secondaryPageKeyMap{
+			JsonPage: jsonPageKeys,
+		}),
 		containers: containers,
 	}
 }
@@ -39,9 +41,11 @@ func (app *App) showContainersPage() error {
 // Build info pages for container page
 func (v *ContainerView) infoBuilder() *tview.Pages {
 	for _, c := range v.containers {
+		title := util.ArnToName(c.ContainerArn)
+		entityName := *c.ContainerArn
 		items := v.infoPagesParam(c)
-		infoFlex := v.buildInfoFlex(util.ArnToName(c.ContainerArn), items, v.keys)
-		v.infoPages.AddPage(*c.ContainerArn, infoFlex, true, true)
+
+		v.buildInfoPages(items, title, entityName)
 	}
 	// prevent empty containers
 	if len(v.containers) > 0 && v.containers[0].ContainerArn != nil {

--- a/ui/json.go
+++ b/ui/json.go
@@ -153,6 +153,7 @@ func (v *View) switchToAutoScalingJson() {
 func (v *View) showJsonPages(entity Entity, which string) {
 	contentString := v.getJsonString(entity, which)
 	v.handleContentPageSwitch(entity, which, contentString)
+	v.handleInfoPageSwitch(entity, which)
 }
 
 func (v *View) handleFullScreenContentInput(event *tcell.EventKey) *tcell.EventKey {
@@ -173,6 +174,9 @@ func (v *View) handleTableContentDone(key tcell.Key) {
 	v.secondaryKind = v.kind
 	pageName := v.kind.getTablePageName(v.getClusterArn())
 	v.tablePages.SwitchToPage(pageName)
+
+	selected, _ := v.getCurrentSelection()
+	v.infoPages.SwitchToPage(*selected.cluster.ClusterArn)
 }
 
 func (v *View) handleFullScreenContentDone(key tcell.Key) {

--- a/ui/json.go
+++ b/ui/json.go
@@ -26,10 +26,13 @@ func (v *View) switchToTaskDefinitionJson() {
 		return
 	}
 	taskDefinition := ""
+	entityName := ""
 	if v.kind == ServicePage {
 		taskDefinition = *selected.service.TaskDefinition
+		entityName = *selected.service.ServiceArn
 	} else if v.kind == TaskPage {
 		taskDefinition = *selected.task.TaskDefinitionArn
+		entityName = *selected.task.TaskArn
 	} else {
 		return
 	}
@@ -38,7 +41,7 @@ func (v *View) switchToTaskDefinitionJson() {
 	if err != nil {
 		return
 	}
-	entity := Entity{taskDefinition: &td, entityName: *td.TaskDefinitionArn}
+	entity := Entity{taskDefinition: &td, entityName: entityName}
 	v.showJsonPages(entity, "task definition")
 }
 
@@ -47,57 +50,35 @@ func (v *View) switchToTaskDefinitionRevisionsJson() {
 	if v.kind == ClusterPage {
 		return
 	}
-	family, _ := v.getTaskDefinitionDetail()
+	family, _, entityName := v.getTaskDefinitionDetail()
 
 	revisions, err := v.app.Store.ListTaskDefinition(&family)
 	if err != nil {
 		return
 	}
-	entity := Entity{taskDefinitionRevisions: revisions, entityName: family}
+	entity := Entity{taskDefinitionRevisions: revisions, entityName: entityName}
 	v.showJsonPages(entity, "revisions")
 }
 
 // Get td family
-func (v *View) getTaskDefinitionDetail() (string, string) {
+func (v *View) getTaskDefinitionDetail() (string, string, string) {
 	selected, err := v.getCurrentSelection()
 	if err != nil {
-		return "", ""
+		return "", "", ""
 	}
 	taskDefinition := ""
+	entityName := ""
 	if v.kind == ServicePage {
 		taskDefinition = *selected.service.TaskDefinition
+		entityName = *selected.service.ServiceArn
 	} else if v.kind == TaskPage {
 		taskDefinition = *selected.task.TaskDefinitionArn
+		entityName = *selected.task.TaskArn
 	} else {
-		return "", ""
+		return "", "", ""
 	}
 	familyRevision := strings.Split(util.ArnToName(&taskDefinition), ":")
-	return familyRevision[0], familyRevision[1]
-}
-
-// Switch to selected service events JSON page
-func (v *View) switchToServiceEventsList() {
-	selected, err := v.getCurrentSelection()
-	if err != nil {
-		return
-	}
-	if v.kind != ServicePage {
-		return
-	}
-	v.showListPages(selected, "events")
-}
-
-// Switch to selected service events JSON page
-func (v *View) switchToLogsList() {
-	if v.kind == ClusterPage || v.kind == ContainerPage {
-		return
-	}
-	selected, err := v.getCurrentSelection()
-	if err != nil {
-		return
-	}
-	v.secondaryKind = LogsPage
-	v.showListPages(selected, "logs")
+	return familyRevision[0], familyRevision[1], entityName
 }
 
 // Deprecated
@@ -153,7 +134,7 @@ func (v *View) switchToAutoScalingJson() {
 func (v *View) showJsonPages(entity Entity, which string) {
 	contentString := v.getJsonString(entity, which)
 	v.handleContentPageSwitch(entity, which, contentString)
-	v.handleInfoPageSwitch(entity, which)
+	v.handleInfoPageSwitch(entity, JsonPage)
 }
 
 func (v *View) handleFullScreenContentInput(event *tcell.EventKey) *tcell.EventKey {
@@ -175,8 +156,11 @@ func (v *View) handleTableContentDone(key tcell.Key) {
 	pageName := v.kind.getTablePageName(v.getClusterArn())
 	v.tablePages.SwitchToPage(pageName)
 
-	selected, _ := v.getCurrentSelection()
-	v.infoPages.SwitchToPage(*selected.cluster.ClusterArn)
+	selected, err := v.getCurrentSelection()
+	if err != nil {
+		v.back()
+	}
+	v.infoPages.SwitchToPage(selected.entityName)
 }
 
 func (v *View) handleFullScreenContentDone(key tcell.Key) {

--- a/ui/json_test.go
+++ b/ui/json_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestGetJsonData(t *testing.T) {
-	view := newView(newApp(), ClusterPage, []KeyInput{})
+	view := newView(newApp(), ClusterPage, []KeyInput{}, secondaryPageKeyMap{
+		JsonPage: []KeyInput{
+			{key: string(fKey), description: toggleFullScreen},
+		},
+	})
 	type input struct {
 		entity Entity
 		which  string

--- a/ui/kind.go
+++ b/ui/kind.go
@@ -11,7 +11,7 @@ const (
 	TaskDefinitionPage
 	TaskDefinitionRevisionsPage
 	ServiceEventsPage
-	LogsPage
+	LogPage
 )
 
 func (k Kind) String() string {
@@ -32,7 +32,7 @@ func (k Kind) String() string {
 		return "taskDefinitionRevisions"
 	case ServiceEventsPage:
 		return "serviceEvents"
-	case LogsPage:
+	case LogPage:
 		return "logs"
 	default:
 		return "unknownKind"
@@ -90,4 +90,19 @@ func (k Kind) getTablePageName(name string) string {
 func (k Kind) getContentPageName(name string) string {
 	pageName := k.getAppPageName(name)
 	return pageName + ".json"
+}
+
+type secondaryPageKeyMap = map[Kind][]KeyInput
+
+var jsonPageKeys = []KeyInput{
+	{key: string(fKey), description: toggleFullScreen},
+	{key: string(bKey), description: openInBrowser},
+	{key: back, description: backToPrevious},
+}
+
+var logPageKeys = []KeyInput{
+	{key: string(fKey), description: toggleFullScreen},
+	{key: string(bKey), description: openInBrowser},
+	{key: ctrlR, description: reloadResource},
+	{key: back, description: backToPrevious},
 }

--- a/ui/list.go
+++ b/ui/list.go
@@ -16,6 +16,7 @@ const (
 func (v *View) showListPages(entity Entity, which string) {
 	contentString := v.getListString(entity, which)
 	v.handleContentPageSwitch(entity, which, contentString)
+	v.handleInfoPageSwitch(entity, LogPage)
 }
 
 // Based on current entity return list string as content
@@ -54,4 +55,29 @@ func (v *View) getListString(entity Entity, which string) string {
 	}
 
 	return contentString
+}
+
+// Switch to selected service events JSON page
+func (v *View) switchToServiceEventsList() {
+	selected, err := v.getCurrentSelection()
+	if err != nil {
+		return
+	}
+	if v.kind != ServicePage {
+		return
+	}
+	v.showListPages(selected, "events")
+}
+
+// Switch to selected service events JSON page
+func (v *View) switchToLogsList() {
+	if v.kind == ClusterPage || v.kind == ContainerPage {
+		return
+	}
+	selected, err := v.getCurrentSelection()
+	if err != nil {
+		return
+	}
+	v.secondaryKind = LogPage
+	v.showListPages(selected, "logs")
 }

--- a/ui/modal.go
+++ b/ui/modal.go
@@ -218,7 +218,7 @@ func (v *View) serviceUpdateContent() (*tview.Form, string) {
 	}
 
 	title := " Update [purple::b]" + name + readonly
-	currentFamily, currentRevision := v.getTaskDefinitionDetail()
+	currentFamily, currentRevision, _ := v.getTaskDefinitionDetail()
 
 	// get data for form
 	families, err := v.app.Store.ListTaskDefinitionFamilies()

--- a/ui/service.go
+++ b/ui/service.go
@@ -27,7 +27,10 @@ func newServiceView(services []types.Service, app *App) *ServiceView {
 		{key: string(lKey), description: showLogs},
 	}...)
 	return &ServiceView{
-		View:     *newView(app, ServicePage, keys),
+		View: *newView(app, ServicePage, keys, secondaryPageKeyMap{
+			JsonPage: jsonPageKeys,
+			LogPage:  logPageKeys,
+		}),
 		services: services,
 	}
 }
@@ -53,9 +56,11 @@ func (app *App) showServicesPage() error {
 // Build info pages for service page
 func (v *ServiceView) infoBuilder() *tview.Pages {
 	for _, s := range v.services {
+		title := *s.ServiceName
+		entityName := *s.ServiceArn
 		items := v.infoPagesParam(s)
-		infoFlex := v.buildInfoFlex(*s.ServiceName, items, v.keys)
-		v.infoPages.AddPage(*s.ServiceArn, infoFlex, true, true)
+
+		v.buildInfoPages(items, title, entityName)
 	}
 	// prevent empty services
 	if len(v.services) > 0 && v.services[0].ServiceArn != nil {

--- a/ui/task.go
+++ b/ui/task.go
@@ -23,7 +23,10 @@ func newTaskView(tasks []types.Task, app *App) *TaskView {
 		{key: string(lKey), description: showLogs},
 	}...)
 	return &TaskView{
-		View:  *newView(app, TaskPage, keys),
+		View: *newView(app, TaskPage, keys, secondaryPageKeyMap{
+			JsonPage: jsonPageKeys,
+			LogPage:  logPageKeys,
+		}),
 		tasks: tasks,
 	}
 }
@@ -50,9 +53,11 @@ func (app *App) showTasksPages() error {
 // Build info pages for task page
 func (v *TaskView) infoBuilder() *tview.Pages {
 	for _, t := range v.tasks {
+		title := util.ArnToName(t.TaskArn)
+		entityName := *t.TaskArn
 		items := v.infoPagesParam(t)
-		infoFlex := v.buildInfoFlex(util.ArnToName(t.TaskArn), items, v.keys)
-		v.infoPages.AddPage(*t.TaskArn, infoFlex, true, true)
+
+		v.buildInfoPages(items, title, entityName)
 	}
 	// prevent empty tasks
 	if len(v.tasks) > 0 && v.tasks[0].TaskArn != nil {

--- a/ui/view.go
+++ b/ui/view.go
@@ -301,6 +301,10 @@ func (v *View) handleContentPageSwitch(entity Entity, which string, contentStrin
 	v.tablePages.AddPage(contentPageName, contentTextItem, true, true)
 }
 
+func (v *View) handleInfoPageSwitch(entity Entity, which string) {
+	v.infoPages.SwitchToPage(*entity.cluster.ClusterArn + "json")
+}
+
 func getContentTextItem(contentStr string, title string) *tview.TextView {
 	contentText := tview.NewTextView().SetDynamicColors(true).SetText(contentStr)
 	contentText.SetBorder(true).SetTitle(title).SetBorderPadding(0, 0, 1, 1)


### PR DESCRIPTION
- feat: support secondary page key bind info change
- show different keys in secondary pages
