### PR TITLE
fix log path documented in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ e1s -version
 ### Logs
 
 ```bash
-tail -f /tmp/e1s_debug.log
+tail -f /tmp/e1s-debug.log
 ```
 
 ## Feature Requests & Bug Reports


### PR DESCRIPTION
This corrects a typo documenting the e1s log path in the README. The correct log path is `/tmp/debug-e1s.log`, as set via this code path:

https://github.com/keidarcy/e1s/blob/v1.0.14/util/util.go#L36

Thanks!