### PR TITLE
ensure all a cluster's services are fetched

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -25,7 +25,11 @@ func (store *Store) ListServices(clusterName *string) ([]types.Service, error) {
 		listServicesOutput, err := store.ecs.ListServices(context.Background(), params)
 		if err != nil {
 			logger.Printf("e1s - aws failed to list services, err: %v\n", err)
-			return []types.Service{}, err
+			// If first run failed return err
+			if len(serviceARNs) == 0 {
+				return []types.Service{}, err
+			}
+			continue
 		}
 
 		if len(listServicesOutput.ServiceArns) == 0 {


### PR DESCRIPTION
This seeks to fix issue #118 by fetching _all_ an ECS cluster's services (and not just the first 100).

Note, however, that issue #116 (fixed by PR #117) more fundamentally prevents the rendering of any service count that is divisble by 10 (or greater than 100).