### PR TITLE
feat: added --profile, --region options

### DIFF
--- a/cmd/e1s/main.go
+++ b/cmd/e1s/main.go
@@ -1,73 +1,79 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
+	"fmt"
+	"os"
+	"path/filepath"
 
-    "github.com/keidarcy/e1s/internal/utils"
-    e1s "github.com/keidarcy/e1s/internal/view"
-    "github.com/spf13/cobra"
+	"github.com/keidarcy/e1s/internal/utils"
+	e1s "github.com/keidarcy/e1s/internal/view"
+	"github.com/spf13/cobra"
 )
 
 var (
-    readOnly    bool
-    debug       bool
-    logFilePath string
-    json        bool
-    refresh     int
-    shell       string
-    profile     string
+	readOnly    bool
+	debug       bool
+	logFilePath string
+	json        bool
+	refresh     int
+	shell       string
+	profile     string
+	region      string
 )
 
 func init() {
-    defaultLogFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s.log", utils.AppName))
+	defaultLogFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s.log", utils.AppName))
 
-    rootCmd.Flags().BoolVarP(&debug, "debug", "d", false, "sets debug mode")
-    rootCmd.Flags().BoolVarP(&json, "json", "j", false, "log output json format")
-    rootCmd.Flags().StringVarP(&logFilePath, "log-file-path", "l", defaultLogFilePath, "specify the log file path")
-    rootCmd.Flags().BoolVar(&readOnly, "readonly", false, "sets readOnly mode")
-    rootCmd.Flags().IntVarP(&refresh, "refresh", "r", 30, "specify the default refresh rate as an integer (sec) (default 30, set -1 to stop auto refresh)")
-    rootCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/sh", "specify ecs exec ssh shell")
-    rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "specify the AWS profile")
+	rootCmd.Flags().BoolVarP(&debug, "debug", "d", false, "sets debug mode")
+	rootCmd.Flags().BoolVarP(&json, "json", "j", false, "log output json format")
+	rootCmd.Flags().StringVarP(&logFilePath, "log-file-path", "l", defaultLogFilePath, "specify the log file path")
+	rootCmd.Flags().BoolVar(&readOnly, "readonly", false, "sets read only mode")
+	rootCmd.Flags().IntVarP(&refresh, "refresh", "r", 30, "specify the default refresh rate as an integer (sec) (default 30, set -1 to stop auto refresh)")
+	rootCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/sh", "specify ecs exec ssh shell")
+	rootCmd.Flags().StringVarP(&profile, "profile", "", "", "specify the AWS profile")
+	rootCmd.Flags().StringVarP(&region, "region", "", "", "specify the AWS region")
 }
 
 var rootCmd = &cobra.Command{
-    Use:   "e1s",
-    Short: "E1s - Easily Manage AWS ECS Resources in Terminal 🐱",
-    Long: `E1s is a terminal application to easily browse and manage AWS ECS resources 🐱. 
+	Use:   "e1s",
+	Short: "E1s - Easily Manage AWS ECS Resources in Terminal 🐱",
+	Long: `E1s is a terminal application to easily browse and manage AWS ECS resources 🐱. 
 Check https://github.com/keidarcy/e1s for more details.`,
-    Run: func(cmd *cobra.Command, args []string) {
-        if profile != "" {
-            os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-            os.Setenv("AWS_PROFILE", profile)
-            defer func() {
-                os.Unsetenv("AWS_SDK_LOAD_CONFIG")
-                os.Unsetenv("AWS_PROFILE")
-            }()
-        }
+	Run: func(cmd *cobra.Command, args []string) {
+		if profile != "" {
+			os.Setenv("AWS_PROFILE", profile)
+			defer func() {
+				os.Unsetenv("AWS_PROFILE")
+			}()
+		}
+		if region != "" {
+			os.Setenv("AWS_REGION", region)
+			defer func() {
+				os.Unsetenv("AWS_REGION")
+			}()
+		}
 
-        logger, file := utils.GetLogger(logFilePath, json, debug)
-        defer file.Close()
+		logger, file := utils.GetLogger(logFilePath, json, debug)
+		defer file.Close()
 
-        option := e1s.Option{
-            ReadOnly: readOnly,
-            Logger:   logger,
-            Refresh:  refresh,
-            Shell:    shell,
-        }
+		option := e1s.Option{
+			ReadOnly: readOnly,
+			Logger:   logger,
+			Refresh:  refresh,
+			Shell:    shell,
+		}
 
-        if err := e1s.Start(option); err != nil {
-            fmt.Printf("e1s failed to start, please check your aws cli credential and permission. error: %v\n", err)
-            logger.Fatalf("Failed to start, error: %v\n", err) // will call os.Exit(1)
-        }
-    },
-    Version: utils.ShowVersion(),
+		if err := e1s.Start(option); err != nil {
+			fmt.Printf("e1s failed to start, please check your aws cli credential and permission. error: %v\n", err)
+			logger.Fatalf("Failed to start, error: %v\n", err) // will call os.Exit(1)
+		}
+	},
+	Version: utils.ShowVersion(),
 }
 
 func main() {
-    if err := rootCmd.Execute(); err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/e1s/main.go
+++ b/cmd/e1s/main.go
@@ -1,63 +1,73 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
+    "fmt"
+    "os"
+    "path/filepath"
 
-	"github.com/spf13/cobra"
-
-	"github.com/keidarcy/e1s/internal/utils"
-	e1s "github.com/keidarcy/e1s/internal/view"
+    "github.com/keidarcy/e1s/internal/utils"
+    e1s "github.com/keidarcy/e1s/internal/view"
+    "github.com/spf13/cobra"
 )
 
 var (
-	readOnly    bool
-	debug       bool
-	logFilePath string
-	json        bool
-	refresh     int
-	shell       string
+    readOnly    bool
+    debug       bool
+    logFilePath string
+    json        bool
+    refresh     int
+    shell       string
+    profile     string
 )
 
 func init() {
-	defaultLogFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s.log", utils.AppName))
+    defaultLogFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s.log", utils.AppName))
 
-	rootCmd.Flags().BoolVarP(&debug, "debug", "d", false, "sets debug mode")
-	rootCmd.Flags().BoolVarP(&json, "json", "j", false, "log output json format")
-	rootCmd.Flags().StringVarP(&logFilePath, "log-file-path", "l", defaultLogFilePath, "specify the log file path")
-	rootCmd.Flags().BoolVar(&readOnly, "readonly", false, "sets readOnly mode")
-	rootCmd.Flags().IntVarP(&refresh, "refresh", "r", 30, "specify the default refresh rate as an integer (sec) (default 30, set -1 to stop auto refresh)")
-	rootCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/sh", "specify ecs exec ssh shell")
+    rootCmd.Flags().BoolVarP(&debug, "debug", "d", false, "sets debug mode")
+    rootCmd.Flags().BoolVarP(&json, "json", "j", false, "log output json format")
+    rootCmd.Flags().StringVarP(&logFilePath, "log-file-path", "l", defaultLogFilePath, "specify the log file path")
+    rootCmd.Flags().BoolVar(&readOnly, "readonly", false, "sets readOnly mode")
+    rootCmd.Flags().IntVarP(&refresh, "refresh", "r", 30, "specify the default refresh rate as an integer (sec) (default 30, set -1 to stop auto refresh)")
+    rootCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/sh", "specify ecs exec ssh shell")
+    rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "specify the AWS profile")
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "e1s",
-	Short: "E1s - Easily Manage AWS ECS Resources in Terminal 🐱",
-	Long: `E1s is a terminal application to easily browse and manage AWS ECS resources 🐱. 
+    Use:   "e1s",
+    Short: "E1s - Easily Manage AWS ECS Resources in Terminal 🐱",
+    Long: `E1s is a terminal application to easily browse and manage AWS ECS resources 🐱. 
 Check https://github.com/keidarcy/e1s for more details.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		logger, file := utils.GetLogger(logFilePath, json, debug)
-		defer file.Close()
+    Run: func(cmd *cobra.Command, args []string) {
+        if profile != "" {
+            os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+            os.Setenv("AWS_PROFILE", profile)
+            defer func() {
+                os.Unsetenv("AWS_SDK_LOAD_CONFIG")
+                os.Unsetenv("AWS_PROFILE")
+            }()
+        }
 
-		option := e1s.Option{
-			ReadOnly: readOnly,
-			Logger:   logger,
-			Refresh:  refresh,
-			Shell:    shell,
-		}
+        logger, file := utils.GetLogger(logFilePath, json, debug)
+        defer file.Close()
 
-		if err := e1s.Start(option); err != nil {
-			fmt.Printf("e1s failed to start, please check your aws cli credential and permission. error: %v\n", err)
-			logger.Fatalf("Failed to start, error: %v\n", err) // will call os.Exit(1)
-		}
-	},
-	Version: utils.ShowVersion(),
+        option := e1s.Option{
+            ReadOnly: readOnly,
+            Logger:   logger,
+            Refresh:  refresh,
+            Shell:    shell,
+        }
+
+        if err := e1s.Start(option); err != nil {
+            fmt.Printf("e1s failed to start, please check your aws cli credential and permission. error: %v\n", err)
+            logger.Fatalf("Failed to start, error: %v\n", err) // will call os.Exit(1)
+        }
+    },
+    Version: utils.ShowVersion(),
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+    if err := rootCmd.Execute(); err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
 }


### PR DESCRIPTION
Not an expert in Go or the AWS SDK but since my team requested this, I did a quick and dirty implementation of the --profile option.
 
Essentially calling ./e1s --profile xxxx will temporarily set AWS_PROFILE to xxxx and unset it afterwards. It works but I haven't tested it a whole bunch.