### PR TITLE
docs: add how to install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ docker pull ghcr.io/keidarcy/e1s:latest
 curl -sL https://raw.githubusercontent.com/keidarcy/e1s-install/master/cloudshell-install.sh | bash
 ```
 
+- Install from source with Go CLI.
+
+```bash
+go install github.com/keidarcy/e1s/cmd/e1s@latest
+```
+
 ## Usage
 
 Make sure you have the AWS CLI installed and properly configured with the necessary permissions to access your ECS resources, and [session manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed if you want to use the interactive exec or port forwarding features.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker pull ghcr.io/keidarcy/e1s:latest
 curl -sL https://raw.githubusercontent.com/keidarcy/e1s-install/master/cloudshell-install.sh | bash
 ```
 
-- Install from source with Go CLI.
+- go install command
 
 ```bash
 go install github.com/keidarcy/e1s/cmd/e1s@latest


### PR DESCRIPTION
## Motivation

It's helpful to know how to install from the source if the other options are impossible. For example, it could be easier for some users to install from a source on Linux than using the binary on the Releases page.

## Changelog

1. Add a section in the README.md about how to install from source.
1. Tested in my local machine running Kubuntu 24.04.
![image](https://github.com/keidarcy/e1s/assets/22875166/3e0f8ca5-5790-44e9-ba55-4353d89b882b)
