### PR TITLE
docs(install): add asdf installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ curl -sL https://raw.githubusercontent.com/keidarcy/e1s-install/master/cloudshel
 go install github.com/keidarcy/e1s/cmd/e1s@latest
 ```
 
+- [asdf-vm](https://asdf-vm.com/)
+
+```bash
+asdf plugin add e1s
+asdf install e1s latest
+asdf global e1s latest
+```
+
 ## Usage
 
 Make sure you have the AWS CLI installed and properly configured with the necessary permissions to access your ECS resources, and [session manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed if you want to use the interactive exec or port forwarding features.


### PR DESCRIPTION
Hi !

Thanks a lot for providing this lovely interface that I've been using for a while now.

I usually deal with my executable based installation using [asdf-vm](https://asdf-vm.com/) which is very convenient and allowed myself to create an asdf plugin for `e1s` (tbobm/asdf-e1s)

If you feel like this could be a nice addition to the readme as an alternative way of installing `e1s`, feel free to merge this PR !


