### PR TITLE
doc: support mise installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ asdf install e1s latest
 asdf global e1s latest
 ```
 
+- [mise](https://github.com/jdx/mise)
+
+```bash
+mise install e1s@latest
+```
+
 ## Usage
 
 Make sure you have the AWS CLI installed and properly configured with the necessary permissions to access your ECS resources, and [session manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed if you want to use the interactive exec or port forwarding features.


### PR DESCRIPTION
This PR adds installation instructions for [mise](https://mise.jdx.dev/), a modern tool version manager, to the README. With this update, users can easily install this tool using mise install.

### Why mise?

I think that mise is one of the most popular version management tools, making it easier for developers to maintain consistent environments across projects.

### Background

There is a person who is already using mise to manage e1s, as evidenced by traces in this [Issue](https://github.com/jdx/mise/issues/2082). I am also one of the users who rely on mise to use this tool efficiently. Adding mise support will benefit the community by providing a seamless installation experience for mise users.

### Corresponding PR

I am working on this PR to add this tool to the official mise registry: https://github.com/jdx/mise/pull/4363