### PR TITLE
fix: don't expect agent/docker versions for managed instances

### DIFF
--- a/internal/view/instance.go
+++ b/internal/view/instance.go
@@ -80,10 +80,17 @@ func (v *instanceView) headerPagesParam(instance types.ContainerInstance) (items
 		{name: "Agent Connected", value: fmt.Sprintf("%v", instance.AgentConnected)},
 		{name: "Running Tasks Count", value: fmt.Sprintf("%d", instance.RunningTasksCount)},
 		{name: "Pending Tasks Count", value: fmt.Sprintf("%d", instance.PendingTasksCount)},
-		{name: "Agent Version", value: utils.ShowString(instance.VersionInfo.AgentVersion)},
-		{name: "Docker Version", value: utils.ShowString(instance.VersionInfo.DockerVersion)},
-		{name: "Registered At", value: utils.ShowTime(instance.RegisteredAt)},
 	}
+
+	// Managed Instances don't have these attributes
+	if instance.VersionInfo != nil {
+		items = append(items,
+			headerItem{name: "Agent Version", value: utils.ShowString(instance.VersionInfo.AgentVersion)},
+			headerItem{name: "Docker Version", value: utils.ShowString(instance.VersionInfo.DockerVersion)},
+		)
+	}
+
+	items = append(items, headerItem{name: "Registered At", value: utils.ShowTime(instance.RegisteredAt)})
 	return
 }
 
@@ -117,6 +124,15 @@ func (v *instanceView) tableParam() (title string, headers []string, dataBuilder
 		clusterName = *v.app.cluster.ClusterName
 	}
 
+	// Check if any instance has VersionInfo
+	hasVersionInfo := false
+	for _, instance := range v.instances {
+		if instance.VersionInfo != nil {
+			hasVersionInfo = true
+			break
+		}
+	}
+
 	title = fmt.Sprintf(color.TableTitleFmt, v.app.kind, clusterName, len(v.instances))
 	headers = []string{
 		"Instance ID ▾",
@@ -124,10 +140,14 @@ func (v *instanceView) tableParam() (title string, headers []string, dataBuilder
 		"Running Tasks",
 		"Pending Tasks",
 		"Agent Connected",
-		"Agent Version",
-		"Docker Version",
-		"Registered At",
 	}
+
+	// Managed Instances don't have these attributes
+	if hasVersionInfo {
+		headers = append(headers, "Agent Version", "Docker Version")
+	}
+
+	headers = append(headers, "Registered At")
 
 	dataBuilder = func() (data [][]string) {
 		for _, instance := range v.instances {
@@ -137,10 +157,19 @@ func (v *instanceView) tableParam() (title string, headers []string, dataBuilder
 				fmt.Sprintf("%d", instance.RunningTasksCount),
 				fmt.Sprintf("%d", instance.PendingTasksCount),
 				fmt.Sprintf("%v", instance.AgentConnected),
-				utils.ShowString(instance.VersionInfo.AgentVersion),
-				utils.ShowString(instance.VersionInfo.DockerVersion),
-				utils.ShowTime(instance.RegisteredAt),
 			}
+
+			if hasVersionInfo {
+				agentVersion := ""
+				dockerVersion := ""
+				if instance.VersionInfo != nil {
+					agentVersion = utils.ShowString(instance.VersionInfo.AgentVersion)
+					dockerVersion = utils.ShowString(instance.VersionInfo.DockerVersion)
+				}
+				row = append(row, agentVersion, dockerVersion)
+			}
+
+			row = append(row, utils.ShowTime(instance.RegisteredAt))
 			data = append(data, row)
 		}
 		return data


### PR DESCRIPTION
Closes: #410 

With EC2, the ECS Agent & Docker version are returned as attribute:

```
$ aws ecs describe-container-instances --cluster arn:aws:ecs:us-west-2:1234567890:cluster/ecs-migration-cluster --container-instances 9de9b156bccd42d6aee6296a7d1742cc --query "containerInstances[].versionInfo" --output table
---------------------------------------------------------
|              DescribeContainerInstances               |
+-----------+----------------+--------------------------+
| agentHash | agentVersion   |      dockerVersion       |
+-----------+----------------+--------------------------+
|  ec39785b |  1.101.0       |  DockerVersion: 25.0.13  |
+-----------+----------------+--------------------------+
```

For ECS Managed Instances this is not the case because it's no more customer responsibility to stay up2date:

```
$ aws ecs describe-container-instances --cluster arn:aws:ecs:us-west-2:1234567890:cluster/retail-store-ecs-cluster --container-instances 5168217885624423b466bad15da4f0f5 --query "containerInstances[].versionInfo" --output table
$
```

This fix propose to remove it from headers & table if not returned in the `ContainerInstance` structure for this case.