### PR TITLE
 feat(api, view): enhance service update with conditional task definition

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -122,6 +122,11 @@ func (store *Store) UpdateService(input *ecs.UpdateServiceInput) (*types.Service
 		desiredCount = int(*input.DesiredCount)
 	}
 
+	enableExecuteCommand := false
+	if input.EnableExecuteCommand != nil {
+		enableExecuteCommand = *input.EnableExecuteCommand
+	}
+
 	slog.Info("update service",
 		slog.Group("parameters",
 			slog.String("cluster", *input.Cluster),
@@ -129,7 +134,7 @@ func (store *Store) UpdateService(input *ecs.UpdateServiceInput) (*types.Service
 			slog.Int("desiredCount", desiredCount),
 			slog.String("taskDefinition", taskDefinition),
 			slog.Bool("forceNewDeployment", input.ForceNewDeployment),
-			slog.Bool("EnableExecuteCommand", *input.EnableExecuteCommand),
+			slog.Bool("EnableExecuteCommand", enableExecuteCommand),
 		),
 	)
 

--- a/internal/view/modal.go
+++ b/internal/view/modal.go
@@ -329,6 +329,8 @@ func (v *view) serviceUpdateForm() (*tview.Form, *string) {
 		execCommand := f.GetFormItemByLabel(execLabel).(*tview.Checkbox).IsChecked()
 
 		if !DeploymentControllerCodeDeploy {
+			currentTaskDefinition := utils.ArnToName(selected.service.TaskDefinition)
+
 			// get task definition with revision
 			_, selectedFamily := f.GetFormItemByLabel(familyLabel).(*tview.DropDown).GetCurrentOption()
 			_, selectedRevision := f.GetFormItemByLabel(revisionLabel).(*tview.DropDown).GetCurrentOption()
@@ -336,10 +338,17 @@ func (v *view) serviceUpdateForm() (*tview.Form, *string) {
 			selectedRevision, _ = strings.CutSuffix(selectedRevision, latest)
 			taskDefinitionWithRevision := selectedFamily + ":" + selectedRevision
 
+			// Only send task definition if it changed. This avoids triggering iam:PassRole
+			// for operators who only want to update desired count / toggles.
+			var taskDefinitionPtr *string
+			if taskDefinitionWithRevision != currentTaskDefinition {
+				taskDefinitionPtr = aws.String(taskDefinitionWithRevision)
+			}
+
 			input = &ecs.UpdateServiceInput{
 				Service:              aws.String(name),
 				Cluster:              v.app.cluster.ClusterName,
-				TaskDefinition:       aws.String(taskDefinitionWithRevision),
+				TaskDefinition:       taskDefinitionPtr,
 				DesiredCount:         aws.Int32(int32(desiredInt)),
 				ForceNewDeployment:   force,
 				EnableExecuteCommand: &execCommand,


### PR DESCRIPTION
 This update improves the service update functionality by conditionally sending the task definition only when it changes, preventing unnecessary IAM(iam:PassRole) role permissions for operators who only wish to update the desired count or toggles.

https://github.com/keidarcy/e1s/issues/429
