### PR TITLE
fix: remove hardcoded pinned rows at the top of the table view

### DIFF
--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -21,7 +21,7 @@ const (
 func (v *view) buildTable(title string, headers []string, rowsBuilder func() [][]string) {
 
 	v.table.
-		SetFixed(5, 5).
+		SetFixed(1, 0).
 		SetSelectable(true, false)
 
 	v.table.


### PR DESCRIPTION
# Problem
The table view unconditionally pins the first 4 rows at the top, keeping them visible at all times regardless of scroll position. This behavior makes sense for small datasets but becomes a hindrance when working with larger ones — in a list of ~100 services for example, having 4 rows permanently fixed provides no useful context and wastes visible space.
# Solution
Remove the hardcoded pinning behavior so that by default no rows are pinned. 
# Changes
Removed the hardcoded pinned row count

# Notes
This is a breaking change for users who depend on the current pinning behavior. A deprecation notice or a config option to restore it may be worth considering before merging.
